### PR TITLE
Update timestamp datatype

### DIFF
--- a/bin/metababel
+++ b/bin/metababel
@@ -93,7 +93,7 @@ def wrote_event_dispatchers(folder, t)
     body = Babeltrace2Gen.context(indent: 1) do
       e.get_getter(event: event_name, arg_variables: arg_variables)
     end
-    arg_variables.insert(0, GeneratedArg.new('uint64_t', 'timestamp')) if default_clock_class
+    arg_variables.insert(0, GeneratedArg.new('int64_t', 'timestamp')) if default_clock_class
     EventInfo.new(e.name, arg_variables, "\n" + body, index_stream_class, index_event_class)
   end
 
@@ -124,7 +124,7 @@ def wrote_creates(folder, t)
     body = Babeltrace2Gen.context(indent: 1) do
       e.get_setter(event: event_name, arg_variables: arg_variables)
     end
-    arg_variables.insert(0, GeneratedArg.new('uint64_t', 'timestamp')) if default_clock_class
+    arg_variables.insert(0, GeneratedArg.new('int64_t', 'timestamp')) if default_clock_class
     EventInfo.new(e.name, arg_variables, "\n" + body, index_stream_class, index_event_class, default_clock_class)
   end
 

--- a/example/btx_dust/callbacks.c
+++ b/example/btx_dust/callbacks.c
@@ -22,7 +22,7 @@ void btx_read_params(void *btx_handle, void *usr_data, btx_params_t *usr_params)
 
 void btx_push_usr_messages(void *btx_handle, void *usr_data, btx_source_status_t *status) {
   usr_data_t *data = (usr_data_t *)usr_data;
-  uint64_t timestamp;
+  int64_t timestamp;
   uint64_t extra_us;
   /* Try to read a line from the input file into individual tokens */
   int count = fscanf(data->file, "%" PRIu64 " %" PRIu64 " %s %[^\n]", &timestamp, &extra_us,
@@ -38,10 +38,10 @@ void btx_push_usr_messages(void *btx_handle, void *usr_data, btx_source_status_t
    * Multiply it by 1,000,000,000 to get nanoseconds since the Unix
    * epoch because the stream's clock's frequency is 1 GHz.
    */
-  timestamp *= UINT64_C(1000000000);
+  timestamp *= INT64_C(1000000000);
 
   /* Add the extra microseconds (as nanoseconds) to `timestamp` */
-  timestamp += extra_us * UINT64_C(1000);
+  timestamp += extra_us * INT64_C(1000);
 
   /* Choose the correct event class, depending on the event name token */
   if (strcmp(data->name_buffer, "send-msg") == 0)


### PR DESCRIPTION
We updated the datatype for the timestamp from `uint64_t` to `int64_t` since [bt_clock_snapshot_get_ns_from_origin](https://babeltrace.org/docs/v2.0/libbabeltrace2/group__api-tir-cs.html#ga5f89ecc84a434af78301189b27c6ecfa)