### PR TITLE
Use upstream_message in place of event in dispatchers

### DIFF
--- a/template/filter.c.erb
+++ b/template/filter.c.erb
@@ -143,7 +143,7 @@ filter_message_iterator_next_processing_reading(
       name_to_dispatcher_t *s = NULL;
       HASH_FIND_STR(common_data->name_to_dispatcher, class_name, s);
       if (s) {
-        (*((dispatcher_t(*))(s->dispatcher)))(s->callbacks, common_data, event,
+        (*((dispatcher_t(*))(s->dispatcher)))(s->callbacks, common_data, upstream_message,
                                               &is_callback_called);
       }
     }
@@ -159,7 +159,7 @@ filter_message_iterator_next_processing_reading(
       if (s) {
         // is_callback_called will only be modified if at least one callback is
         // called.
-        (*((dispatcher_t(*))(s->dispatcher)))(s->callbacks, common_data, event,
+        (*((dispatcher_t(*))(s->dispatcher)))(s->callbacks, common_data, upstream_message,
                                               &is_callback_called);
       }
     }

--- a/template/sink.c.erb
+++ b/template/sink.c.erb
@@ -48,14 +48,14 @@ sink_consume(bt_self_component_sink *self_component_sink) {
   }
   /* For each consumed message */
   for (uint64_t i = 0; i < message_count; i++) {
-    const bt_message *message = messages[i];
-    if (bt_message_get_type(message) != BT_MESSAGE_TYPE_EVENT) {
-      bt_message_put_ref(message);
+    const bt_message *upstream_message = messages[i];
+    if (bt_message_get_type(upstream_message) != BT_MESSAGE_TYPE_EVENT) {
+      bt_message_put_ref(upstream_message);
       continue;
     }
 
     /* Borrow the event message's event and its class */
-    const bt_event *event = bt_message_event_borrow_event_const(message);
+    const bt_event *event = bt_message_event_borrow_event_const(upstream_message);
     const bt_event_class *event_class = bt_event_borrow_class_const(event);
 
     /* Call dispatcher */
@@ -66,7 +66,7 @@ sink_consume(bt_self_component_sink *self_component_sink) {
       name_to_dispatcher_t *s = NULL;
       HASH_FIND_STR(common_data->name_to_dispatcher, class_name, s);
       if (s) {
-        (*((dispatcher_t(*))(s->dispatcher)))(s->callbacks, common_data, event,
+        (*((dispatcher_t(*))(s->dispatcher)))(s->callbacks, common_data, upstream_message,
                                               &is_callback_called);
       }
     }
@@ -82,12 +82,12 @@ sink_consume(bt_self_component_sink *self_component_sink) {
       if (s) {
         // is_callback_called will only be modified if at least one callback is
         // called.
-        (*((dispatcher_t(*))(s->dispatcher)))(s->callbacks, common_data, event,
+        (*((dispatcher_t(*))(s->dispatcher)))(s->callbacks, common_data, upstream_message,
                                               &is_callback_called);
       }
     }
 
-    bt_message_put_ref(message);
+    bt_message_put_ref(upstream_message);
   }
 end:
   return status;

--- a/template/upstream.c.erb
+++ b/template/upstream.c.erb
@@ -10,11 +10,12 @@
 <% event_class_dispatchers.each do |e| %>
 static void btx_dispatch_<%= e.name_sanitized %>(
     UT_array *callbacks, common_data_t *common_data,
-    const bt_event *<%= event_name %>, bool *is_callback_called) {
+    const bt_message *upstream_message, bool *is_callback_called) {
 
   <% e.args.each do |s| %>
   <%= s.type %> <%= s.name %>;
   <% end %>
+  const bt_event *<%= event_name %> = bt_message_event_borrow_event_const(upstream_message);
   <%= e.body %>
   // Call all the callbacks who where registered
   // Their type are declared in 'upstream.h'
@@ -58,14 +59,15 @@ void btx_register_callbacks_<%= e.name_sanitized %>(
 <% stream_classes_matching_dispatchers.each do |s| %>
 void btx_matching_dispatch_<%= s.name_sanitized %>(UT_array *callbacks,
                                                    common_data_t *common_data,
-                                                   const bt_event *event,
+                                                   const bt_message *upstream_message,
                                                    bool *is_callback_called) {
 
   <% s.args.each do |a| %>
   <%= a.type %> <%= a.name %>;
   <% end %>
+  const bt_event *<%= event_name %> = bt_message_event_borrow_event_const(upstream_message);
   <%= s.body %>
-  const bt_event_class *event_class = bt_event_borrow_class_const(event);
+  const bt_event_class *event_class = bt_event_borrow_class_const(<%= event_name %>);
   const char *event_class_name = bt_event_class_get_name(event_class);
 
   condition_to_callback_t **p = NULL;

--- a/template/upstream.h.erb
+++ b/template/upstream.h.erb
@@ -6,7 +6,7 @@ extern "C" {
 
 // Dispatcher
 typedef void(dispatcher_t)(UT_array *callbacks, common_data_t *common_data,
-                           const bt_event *message, bool *is_callback_called);
+                           const bt_message *upstream_message, bool *is_callback_called);
 
 <% event_class_dispatchers.each do |e| %>
 <%# The signature type of callbacks %>


### PR DESCRIPTION
* We replaced the event passed as argument to the dispatchers by the upstream_message. This allow us unpack the timestamp data from the message within the dispacthers.

```c
  const bt_clock_snapshot *clock_snapshot = bt_message_event_borrow_default_clock_snapshot_const(upstream_message);
  bt_clock_snapshot_get_ns_from_origin(clock_snapshot, &timestamp); 
```