### PR TITLE
Fix stream class name being null

### DIFF
--- a/lib/metababel/version.rb
+++ b/lib/metababel/version.rb
@@ -1,3 +1,3 @@
 module Metababel
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/lib/metababel/version.rb
+++ b/lib/metababel/version.rb
@@ -1,3 +1,3 @@
 module Metababel
-  VERSION = '0.0.5'
+  VERSION = '0.0.4'
 end

--- a/template/filter.c.erb
+++ b/template/filter.c.erb
@@ -122,8 +122,9 @@ static inline void filter_message_iterator_next_call_dispatchers(
     const char *stream_class_name = bt_stream_class_get_name(stream_class);
 
     name_to_dispatcher_t *s = NULL;
-    HASH_FIND_STR(common_data->name_to_matching_dispatcher, stream_class_name,
-                  s);
+    if (stream_class_name)
+      HASH_FIND_STR(common_data->name_to_matching_dispatcher,
+                    stream_class_name, s);
     if (s)
       (*((dispatcher_t(*))(s->dispatcher)))(
           s->callbacks, common_data, upstream_message, &is_callback_called);

--- a/template/sink.c.erb
+++ b/template/sink.c.erb
@@ -77,8 +77,9 @@ sink_consume(bt_self_component_sink *self_component_sink) {
       const char *stream_class_name = bt_stream_class_get_name(stream_class);
 
       name_to_dispatcher_t *s = NULL;
-      HASH_FIND_STR(common_data->name_to_matching_dispatcher, stream_class_name,
-                    s);
+      if (stream_class_name)
+        HASH_FIND_STR(common_data->name_to_matching_dispatcher, stream_class_name,
+                      s);
       if (s) {
         // is_callback_called will only be modified if at least one callback is
         // called.


### PR DESCRIPTION
As per the documentation [bt_stream_class_get_name](https://babeltrace.org/docs/v2.0/libbabeltrace2/group__api-tir-stream-cls.html#ga8bf0ce32d25ae73b14aa2b42295fa731) returns NULL when the class has not been set a name.

Fixes https://github.com/TApplencourt/metababel/issues/70