### PR TITLE
Improve matching callbacks calling order validation test

### DIFF
--- a/test/cases_matching_callbacks/2.btx_log.in
+++ b/test/cases_matching_callbacks/2.btx_log.in
@@ -1,1 +1,1 @@
-event_1: 
+event_1: { callback = "" }

--- a/test/cases_matching_callbacks/2.btx_log.out
+++ b/test/cases_matching_callbacks/2.btx_log.out
@@ -1,2 +1,2 @@
-foo
-bar
+event_1: { callback = "usr_foo_callback" }
+event_1: { callback = "usr_bar_callback" }

--- a/test/cases_matching_callbacks/2.btx_model.yaml
+++ b/test/cases_matching_callbacks/2.btx_model.yaml
@@ -2,3 +2,9 @@
 - :name: sc
   :event_classes:
   - :name: event_1
+    :payload_field_class:
+      :type: structure
+      :members:
+      - :name: callback
+        :field_class:
+          :type: string

--- a/test/cases_matching_callbacks/2.callbacks.c
+++ b/test/cases_matching_callbacks/2.callbacks.c
@@ -1,12 +1,11 @@
 #include <metababel/metababel.h>
-#include <stdio.h>
 
 static void usr_foo_callback(void *btx_handle, void *usr_data) {
-  printf("foo\n");
+  btx_push_message_event_1(btx_handle,"usr_foo_callback");
 }
 
 static void usr_bar_callback(void *btx_handle, void *usr_data) {
-  printf("bar\n");
+  btx_push_message_event_1(btx_handle,"usr_bar_callback");
 }
 
 void btx_register_usr_callbacks(void *btx_handle) {

--- a/test/test_filter_matching_callbacks.rb
+++ b/test/test_filter_matching_callbacks.rb
@@ -28,7 +28,7 @@ class TestFilterMatchingCallbackSubsetOfMembersInDifferentOrder < Test::Unit::Te
 end
 
 class TestFilterMatchingCallbackCallingOrder < Test::Unit::TestCase
-  # Verify the order in with matching are called
+  # Verify the order on which matching are called
 
   include GenericTest
   extend VariableAccessor


### PR DESCRIPTION
* We moved out the printing used for the validation of the order on which matching callbacks are called.