### PR TITLE
Add support to match event_class_name in matching callbacks

### DIFF
--- a/bin/metababel
+++ b/bin/metababel
@@ -78,7 +78,7 @@ DispatchType = Struct.new(:name, :args, :id) do
   end
 end
 
-Dispacther = Struct.new(:name, :args, :body, :index_stream_class,
+Dispatcher = Struct.new(:name, :args, :body, :index_stream_class,
                         :index_event_class, :default_clock_class,
                         :args_to_free, :dispatch_types) do
   def name_sanitized
@@ -138,7 +138,7 @@ def wrote_event_dispatchers(folder, t, matching_dispatch_data, callback_types)
       DispatchType.new(sanitize(md[:name]), dispatcher_evt_args, "matching_#{sanitize(md[:name])}") if not dispatcher_evt_args.nil?
     end
 
-    Dispacther.new(
+    Dispatcher.new(
       e.name, arg_variables.fetch('outputs', []),
       body, index_stream_class, index_event_class,
       default_clock_class,
@@ -170,7 +170,7 @@ def wrote_creates(folder, t)
     body = Babeltrace2Gen.context(indent: 1) do
       e.get_setter(event: event_name, arg_variables: arg_variables)
     end
-    Dispacther.new(e.name, arg_variables.fetch('outputs', []), "\n" + body, index_stream_class, index_event_class,
+    Dispatcher.new(e.name, arg_variables.fetch('outputs', []), "\n" + body, index_stream_class, index_event_class,
                    default_clock_class)
   end
 
@@ -188,16 +188,16 @@ def wrote_creates(folder, t)
 end
 
 def wrote_component(options, d, folder)
-  component_dispatchers = [Dispacther.new('initialize_usr_data',
+  component_dispatchers = [Dispatcher.new('initialize_usr_data',
                                           [GeneratedArg.new('void **', 'usr_data_p')]),
-                           Dispacther.new('finalize_usr_data',
+                           Dispatcher.new('finalize_usr_data',
                                           [GeneratedArg.new('void *', 'usr_data')]),
-                           Dispacther.new('read_params',
+                           Dispatcher.new('read_params',
                                           [GeneratedArg.new('void *', 'usr_data'),
                                            GeneratedArg.new('btx_params_t *', 'usr_params')])]
 
   if options[:component_type] == 'SOURCE'
-    component_dispatchers << Dispacther.new('push_usr_messages',
+    component_dispatchers << Dispatcher.new('push_usr_messages',
                                             [GeneratedArg.new('void *', 'usr_data'),
                                              GeneratedArg.new('btx_source_status_t*', 'status')])
   end

--- a/bin/metababel
+++ b/bin/metababel
@@ -132,8 +132,9 @@ def wrote_event_dispatchers(folder, t, matching_dispatch_data, callback_types)
     dispatch_types = [DispatchType.new(e.name_sanitized, evt_args, 'generic')]
 
     # User event dispatchers
+    usr_evt_args = evt_args + [GeneratedArg.new('const char *', '_event_class_name')]
     dispatch_types += matching_dispatch_data.filter_map do |md|
-      dispatcher_evt_args = btx_get_matching_args(e.name, evt_args, md[:regex], md.fetch(:args,[]))
+      dispatcher_evt_args = btx_get_matching_args(e.name, usr_evt_args, md[:regex], md.fetch(:args,[]))
       DispatchType.new(sanitize(md[:name]), dispatcher_evt_args, "matching_#{sanitize(md[:name])}") if not dispatcher_evt_args.nil?
     end
 

--- a/template/upstream.c.erb
+++ b/template/upstream.c.erb
@@ -28,6 +28,10 @@ static void btx_dispatch_<%= dispatcher.name_sanitized %>(
       bt_message_event_borrow_default_clock_snapshot_const(upstream_message);
   bt_clock_snapshot_get_ns_from_origin(clock_snapshot, &_timestamp);
   <% end %>
+  <%# event_class_name is only required for matching callbacks.  %>
+  <% if dispatcher.dispatch_types.map(&:args).flatten.any? { |arg| arg.name.match?(/^_event_class_name$/) } %>
+  const char *_event_class_name = "<%= dispatcher.name_sanitized %>";
+  <% end %>
 
   // Call registered matching callbacks
   <% dispatcher.dispatch_types.each do |dispatch_type| %>

--- a/template/upstream.c.erb
+++ b/template/upstream.c.erb
@@ -29,7 +29,7 @@ static void btx_dispatch_<%= dispatcher.name_sanitized %>(
   bt_clock_snapshot_get_ns_from_origin(clock_snapshot, &_timestamp);
   <% end %>
   <%# event_class_name, only required when at least one matching callback match it as argument.  %>
-  <% if dispatcher.dispatch_types.map(&:args).flatten.any? { |arg| arg.name.match?(/^_event_class_name$/) } %>
+  <% if dispatcher.dispatch_types.map(&:args).flatten.any? { |arg| arg.name == '_event_class_name' } %>
   const char *_event_class_name = "<%= dispatcher.name_sanitized %>";
   <% end %>
 

--- a/template/upstream.c.erb
+++ b/template/upstream.c.erb
@@ -28,7 +28,7 @@ static void btx_dispatch_<%= dispatcher.name_sanitized %>(
       bt_message_event_borrow_default_clock_snapshot_const(upstream_message);
   bt_clock_snapshot_get_ns_from_origin(clock_snapshot, &_timestamp);
   <% end %>
-  <%# event_class_name is only required for matching callbacks.  %>
+  <%# event_class_name, only required when at least one matching callback match it as argument.  %>
   <% if dispatcher.dispatch_types.map(&:args).flatten.any? { |arg| arg.name.match?(/^_event_class_name$/) } %>
   const char *_event_class_name = "<%= dispatcher.name_sanitized %>";
   <% end %>

--- a/test/callbacks/cases_matching_callbacks/8.btx_callbacks.yaml
+++ b/test/callbacks/cases_matching_callbacks/8.btx_callbacks.yaml
@@ -2,4 +2,3 @@
   :regex: /event/
   :args:
     - _event_class_name
-

--- a/test/callbacks/cases_matching_callbacks/8.btx_callbacks.yaml
+++ b/test/callbacks/cases_matching_callbacks/8.btx_callbacks.yaml
@@ -1,0 +1,5 @@
+- :name: usr_event
+  :regex: /event/
+  :args:
+    - _event_class_name
+

--- a/test/callbacks/cases_matching_callbacks/8.btx_log.txt
+++ b/test/callbacks/cases_matching_callbacks/8.btx_log.txt
@@ -1,0 +1,1 @@
+event: { event_class_name = "event" }

--- a/test/callbacks/cases_matching_callbacks/8.btx_model.yaml
+++ b/test/callbacks/cases_matching_callbacks/8.btx_model.yaml
@@ -1,0 +1,10 @@
+:stream_classes:
+- :name: sc
+  :event_classes:
+  - :name: event
+    :payload_field_class:
+      :type: structure
+      :members:
+      - :name: event_class_name
+        :field_class:
+          :type: string

--- a/test/callbacks/cases_matching_callbacks/8.callbacks.c
+++ b/test/callbacks/cases_matching_callbacks/8.callbacks.c
@@ -1,0 +1,9 @@
+#include <metababel/metababel.h>
+
+static void usr_event_callback(void *btx_handle, void *usr_data, const char *event_class_name) {
+  btx_push_message_event(btx_handle, event_class_name);
+}
+
+void btx_register_usr_callbacks(void *btx_handle) {
+  btx_register_callbacks_usr_event(btx_handle, &usr_event_callback);
+}

--- a/test/callbacks/test_matching_callbacks.rb
+++ b/test/callbacks/test_matching_callbacks.rb
@@ -182,3 +182,30 @@ class TestMatchingSimilarMembers < Test::Unit::TestCase
     ]
   end
 end
+
+class TestCallMatchingCallbackWithEventName < Test::Unit::TestCase
+  # Validate the _event_class_name is passed properly in matchinig callbacks.
+
+  include GenericTest
+  extend VariableAccessor
+  include VariableClassAccessor
+
+  def self.startup
+    @btx_components = [
+      {
+        btx_component_type: 'SOURCE',
+        btx_component_downstream_model: './test/callbacks/cases_matching_callbacks/8.btx_model.yaml',
+        btx_log_path: './test/callbacks/cases_matching_callbacks/8.btx_log.txt'
+      },
+      {
+        btx_component_type: 'FILTER',
+        btx_component_upstream_model: './test/callbacks/cases_matching_callbacks/8.btx_model.yaml',
+        btx_component_downstream_model: './test/callbacks/cases_matching_callbacks/8.btx_model.yaml',
+        btx_component_callbacks: './test/callbacks/cases_matching_callbacks/8.btx_callbacks.yaml',
+        btx_file_usr_callbacks: './test/callbacks/cases_matching_callbacks/8.callbacks.c'
+      }
+    ]
+
+    @btx_output_validation = './test/callbacks/cases_matching_callbacks/8.btx_log.txt'
+  end
+end


### PR DESCRIPTION
We added `_event_class_name` as an argument to be matched in matching callbacks. Since this parameter is not a proper argument in an event, we prefix it with `_`, but this can be completely transparent to the user, we can just use `event_name` hopping this to not colide with the name of any event argument.