### PR TITLE
update bt_match_attrs to contants

### DIFF
--- a/lib/metababel/bt2_matching_utils.rb
+++ b/lib/metababel/bt2_matching_utils.rb
@@ -8,18 +8,12 @@ module HashRefinements
   end
 end
 
-#TODO: Inheritance should do it for us
-def find_bt_match_attrs(c)
-  a = c.instance_variable_get(:@bt_match_attrs)
-  a || find_bt_match_attrs(c.superclass)
-end
-
 module Babeltrace2Gen
   using HashRefinements
 
   module BTMatch
     def match?(match_obj)
-      attrs_syms = find_bt_match_attrs(self.class)
+      attrs_syms = self.class::BT_MATCH_ATTRS
       attrs = attrs_syms.map do |attr_sym|
         match_attr = match_obj.send(attr_sym)
         # In the model, but not in the match, assuming True
@@ -40,7 +34,7 @@ module Babeltrace2Gen
   module BTMatchMembers
     def match?(match_obj)
       # Object here have only one symbol, who cannot be nil
-      attr_sym = find_bt_match_attrs(self.class)[0]
+      attr_sym = self.class::BT_MATCH_ATTRS[0]
 
       self_members = send(attr_sym)
       match_members = match_obj.send(attr_sym)

--- a/lib/metababel/bt2_trace_class_generator.rb
+++ b/lib/metababel/bt2_trace_class_generator.rb
@@ -78,7 +78,7 @@ module Babeltrace2Gen
     include BTMatch
     extend BTFromH
 
-    @bt_match_attrs = [:environment]
+    BT_MATCH_ATTRS = [:environment]
 
     attr_reader :stream_classes, :environment, :assigns_automatic_stream_class_id, :match
 
@@ -124,7 +124,7 @@ module Babeltrace2Gen
     include BTMatch
     extend BTFromH
 
-    @bt_match_attrs = [:parent, :name, :packet_context_field_class, :event_common_context_field_class, :default_clock_class]
+    BT_MATCH_ATTRS = [:parent, :name, :packet_context_field_class, :event_common_context_field_class, :default_clock_class]
   
     attr_reader :packet_context_field_class, :event_common_context_field_class, :event_classes, :default_clock_class,
                 :id, :name, :get_getter
@@ -242,7 +242,7 @@ module Babeltrace2Gen
     include BTMatch
     extend BTFromH
 
-    @bt_match_attrs = [:parent, :name, :specific_context_field_class, :payload_field_class]
+    BT_MATCH_ATTRS = [:parent, :name, :specific_context_field_class, :payload_field_class]
 
     attr_reader :name, :specific_context_field_class, :payload_field_class, :callback_name
 
@@ -362,7 +362,7 @@ module Babeltrace2Gen
     include BTMatch
     using HashRefinements
 
-    @bt_match_attrs = [:type, :cast_type]
+    BT_MATCH_ATTRS = [:type, :cast_type]
 
     attr_accessor :cast_type, :type
 
@@ -690,7 +690,7 @@ module Babeltrace2Gen
     include BTMatch
     include BTLocator
 
-    @bt_match_attrs = [:name, :field_class]
+    BT_MATCH_ATTRS = [:name, :field_class]
   
     attr_reader :parent, :name, :field_class, :extract
 
@@ -712,7 +712,7 @@ module Babeltrace2Gen
 
     attr_reader :members
 
-    @bt_match_attrs = [ :members ]
+    BT_MATCH_ATTRS = [:members]
 
     def initialize(parent:, members: [])
       @parent = parent
@@ -873,7 +873,7 @@ module Babeltrace2Gen
     extend BTFromH
     attr_reader :parent, :entries
 
-    @bt_match_attrs = [:entries]
+    BT_MATCH_ATTRS = [:entries]
 
     def initialize(parent:, entries: [])
       @parent = parent
@@ -894,7 +894,7 @@ module Babeltrace2Gen
     include BTMatch
     using HashRefinements
 
-    @bt_match_attrs = [:name, :type]
+    BT_MATCH_ATTRS = [:name, :type]
 
     attr_accessor :name, :type, :extract
 


### PR DESCRIPTION
* We updated @bt_match_attrs class attributes to constants, according to @Kerilk suggestion. Constants make more sense since bt_match_attrs are not supposed to be changed. This also fixes the inheritance issue when accessing class_instance_attributes.