### PR TITLE
Fix support for packet_context_field

### DIFF
--- a/lib/metababel/bt2_trace_class_generator.rb
+++ b/lib/metababel/bt2_trace_class_generator.rb
@@ -179,6 +179,10 @@ module Babeltrace2Gen
       end
 
       if @packet_context_field_class
+        # Support for packets required for packet_context_field_class
+        # We do not support create_packet neither packet_beginning_default_clock_snapshot (BT_FALSE) nor packet_end_default_clock_snapshot (BT_FALSE)
+        pr "bt_stream_class_set_supports_packets(#{variable}, BT_TRUE, BT_FALSE, BT_FALSE);"
+
         var_pc = "#{variable}_pc_fc"
         scope do
           pr "bt_field_class *#{var_pc};"

--- a/lib/metababel/bt2_trace_class_generator.rb
+++ b/lib/metababel/bt2_trace_class_generator.rb
@@ -138,8 +138,6 @@ module Babeltrace2Gen
       @parent = parent
       @name = name
 
-      raise 'Two packet_context' if packet_context_field_class && packet_context
-
       # Should put assert to check for struct
       @packet_context_field_class = BTFieldClass.from_h(self, packet_context_field_class) if packet_context_field_class
 

--- a/test/model/cases_model_constructs/10.btx_model.yaml
+++ b/test/model/cases_model_constructs/10.btx_model.yaml
@@ -1,0 +1,9 @@
+:stream_classes:
+- :name: sc
+  :packet_context_field_class:
+    :type: structure
+    :members:
+    - :name: dummy
+      :field_class:
+        :type: string
+  :event_classes: []

--- a/test/model/test_model_constructs.rb
+++ b/test/model/test_model_constructs.rb
@@ -139,3 +139,18 @@ class TestUnSupportedEnvironmentInDownstreamModel < Test::Unit::TestCase
     ]
   end
 end
+
+class TestPacketContextField < Test::Unit::TestCase
+  include GenericTest
+  extend VariableAccessor
+  include VariableClassAccessor
+
+  def self.startup
+    @btx_components = [
+      {
+        btx_component_type: 'SOURCE',
+        btx_component_downstream_model: './test/model/cases_model_constructs/10.btx_model.yaml',
+      }
+    ]
+  end
+end


### PR DESCRIPTION
We added the missing call to [bt_stream_class_set_supports_packets](https://babeltrace.org/docs/v2.0/libbabeltrace2/group__api-tir-stream-cls.html#gac4da8f2c7f98d2f65493d1dc7dd36578)  required to work with `packet_context_field`.

__NOTE:__ Since we do not support the creation of messages in packets, then we neither support `packet_beginning_default_clock_snapshot` (BT_FALSE) nor `packet_end_default_clock_snapshot` (BT_FALSE). Then:

```c
bt_stream_class_set_supports_packets(stream, BT_TRUE, BT_FALSE, BT_FALSE)
```