### PR TITLE
Add cast_type_is_struct keyword, move usr_header import out of extern decl

### DIFF
--- a/lib/metababel/bt2_trace_class_generator.rb
+++ b/lib/metababel/bt2_trace_class_generator.rb
@@ -607,7 +607,7 @@ module Babeltrace2Gen
       variable = bt_get_variable(arg_variables).name
 
       pr "// Dump data to a temporal string."
-      pr "char *#{field}_temp = malloc(sizeof(pf_1));"
+      pr "char *#{field}_temp = malloc(sizeof(#{variable}));"
       pr "assert(#{field}_temp != NULL && \"Out of memory\");"
       pr "memcpy(#{field}_temp, &#{variable}, sizeof(#{variable}));"
       pr ""

--- a/template/component.h.erb
+++ b/template/component.h.erb
@@ -4,6 +4,9 @@
 #include "uthash.h"
 #include <babeltrace2/babeltrace.h>
 #include <stdbool.h>
+<% if options.key?(:usr_data_header) %>
+#include "<%= options[:usr_data_header] %>"
+<% end %>
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,10 +30,6 @@ struct btx_params_s {
 typedef struct btx_params_s btx_params_t;
 
 void btx_populate_params(common_data_t *common_data_t);
-
-<% if options.key?(:usr_data_header) %>
-#include "<%= options[:usr_data_header] %>"
-<% end %>
 
 struct callbacks_s {
   <% callback_types.each do |c| %>

--- a/template/upstream.c.erb
+++ b/template/upstream.c.erb
@@ -36,9 +36,9 @@ static void btx_dispatch_<%= dispatcher.name_sanitized %>(
   <% dispatcher.dispatch_types.each do |dispatch_type| %>
   {
     if (callbacks-><%= dispatch_type.id %>) {
-      void **p = NULL;
-      while ((p = utarray_next(callbacks-><%= dispatch_type.id %>, p))) {
-        (*((<%= dispatch_type.name_sanitized %>_callback_f **)(p)))(
+      void **_p = NULL;
+      while ((_p = utarray_next(callbacks-><%= dispatch_type.id %>, _p))) {
+        (*((<%= dispatch_type.name_sanitized %>_callback_f **)(_p)))(
             (void *)common_data,
             common_data
                 ->usr_data<%= dispatch_type.args.map{ |a| a.name }.join_with_prefix(", ") %>);

--- a/test/model/cases_usr_header/1.btx_model.yaml
+++ b/test/model/cases_usr_header/1.btx_model.yaml
@@ -10,3 +10,4 @@
         :field_class:
           :type: string
           :cast_type: struct MyStruct
+          :cast_type_is_struct: true


### PR DESCRIPTION
* We add the `:cast_type_is_true` keyword to the model in order to cast structs into a string (blob) appropriately.
* We moved the user header import out of the extend declaration to avoid the `Template with C linkage` error.