### PR TITLE
Add cast_type_is_struct keyword, move usr_header import out of extern decl

### DIFF
--- a/template/component.h.erb
+++ b/template/component.h.erb
@@ -4,6 +4,9 @@
 #include "uthash.h"
 #include <babeltrace2/babeltrace.h>
 #include <stdbool.h>
+<% if options.key?(:usr_data_header) %>
+#include "<%= options[:usr_data_header] %>"
+<% end %>
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,10 +30,6 @@ struct btx_params_s {
 typedef struct btx_params_s btx_params_t;
 
 void btx_populate_params(common_data_t *common_data_t);
-
-<% if options.key?(:usr_data_header) %>
-#include "<%= options[:usr_data_header] %>"
-<% end %>
 
 struct callbacks_s {
   <% callback_types.each do |c| %>

--- a/test/model/cases_usr_header/1.btx_model.yaml
+++ b/test/model/cases_usr_header/1.btx_model.yaml
@@ -10,3 +10,4 @@
         :field_class:
           :type: string
           :cast_type: struct MyStruct
+          :cast_type_is_struct: true

--- a/test/model/cases_usr_header/1.btx_model.yaml
+++ b/test/model/cases_usr_header/1.btx_model.yaml
@@ -9,5 +9,5 @@
       - :name: pf_1
         :field_class:
           :type: string
-          :cast_type: struct MyStruct
+          :cast_type: usr_struct_t
           :cast_type_is_struct: true

--- a/test/model/cases_usr_header/1.usr_header.h
+++ b/test/model/cases_usr_header/1.usr_header.h
@@ -1,3 +1,5 @@
 struct MyStruct {
     char *dummy;
 };
+
+typedef struct MyStruct usr_struct_t;


### PR DESCRIPTION
* We add the `:cast_type_is_true` keyword to the model in order to cast structs into a string (blob) appropriately.
* We moved the user header import out of the extend declaration to avoid the `Template with C linkage` error.