### PR TITLE
[Draft] Match model keywords

### DIFF
--- a/lib/metababel/bt2_matching_utils.rb
+++ b/lib/metababel/bt2_matching_utils.rb
@@ -21,11 +21,11 @@ module Babeltrace2Gen
 
         self_attr = send(attr_sym)
 
-        # If structure is absent in the model, then match.
-        # TODO: We can place this as a special case of Structure type
-        # But we will need to duplicate the same lines of code to
-        # place a new one.
-        next true if match_attr.instance_variable_get(:@absent) && self_attr.nil?
+        # Check if the absent keyword exists, match in either case:
+        # 1) the attr_sym is present (absent = false) in the matching and in the model.
+        # 2) the attr_sym is absent (absent = true) in the matching and the model.
+        absent = match_attr.instance_variable_get(:@absent)
+        next true if absent.nil? ? false : (absent == self_attr.nil?)
 
         # Not matching because in the match but not in the model
         next false if self_attr.nil?

--- a/lib/metababel/bt2_matching_utils.rb
+++ b/lib/metababel/bt2_matching_utils.rb
@@ -20,6 +20,13 @@ module Babeltrace2Gen
         next true if match_attr.nil?
 
         self_attr = send(attr_sym)
+
+        # If structure is absent in the model, then match.
+        # TODO: We can place this as a special case of Structure type
+        # But we will need to duplicate the same lines of code to
+        # place a new one.
+        next true if match_attr.instance_variable_get(:@absent) && self_attr.nil?
+
         # Not matching because in the match but not in the model
         next false if self_attr.nil?
 

--- a/lib/metababel/bt2_trace_class_generator.rb
+++ b/lib/metababel/bt2_trace_class_generator.rb
@@ -753,7 +753,7 @@ module Babeltrace2Gen
 
     BT_MATCH_ATTRS = [:members]
 
-    def initialize(parent:, members: [], absent: false)
+    def initialize(parent:, members: [], absent: nil)
       @parent = parent
       @absent = absent
       @members = members.collect { |m| BTMemberClass.new(parent: self, **m) }

--- a/lib/metababel/bt2_trace_class_generator.rb
+++ b/lib/metababel/bt2_trace_class_generator.rb
@@ -744,12 +744,18 @@ module Babeltrace2Gen
     include BTMatchMembers
     extend BTFromH
 
-    attr_reader :members
+    # :absent used for matching purposes.
+    # In some cases, we need to tell the matching mechanism that a given
+    # structure (common_field, payload, etc) is not present in the model
+    # and we need to consider it as a match. For instance, match all the
+    # events matching name 'X regex' that do not have payload_field.
+    attr_reader :members, :absent
 
     BT_MATCH_ATTRS = [:members]
 
-    def initialize(parent:, members: [])
+    def initialize(parent:, members: [], absent: false)
       @parent = parent
+      @absent = absent
       @members = members.collect { |m| BTMemberClass.new(parent: self, **m) }
     end
 

--- a/test/callbacks/cases_matching_callbacks/11.btx_callbacks.yaml
+++ b/test/callbacks/cases_matching_callbacks/11.btx_callbacks.yaml
@@ -5,12 +5,7 @@
     :callback_name: usr_event_1
     :payload_field_class:
       :type: structure
-      :members:
-      - :name: pf_1
-        :extract: false
-        :field_class:
-          :type: integer_unsigned
-          :cast_type: uint64_t
+      :absent: false
   - :name: ^event_[1-2]$
     :callback_name: usr_event_2
     :payload_field_class:

--- a/test/callbacks/cases_matching_callbacks/11.btx_callbacks.yaml
+++ b/test/callbacks/cases_matching_callbacks/11.btx_callbacks.yaml
@@ -1,0 +1,18 @@
+:stream_classes:
+- :name: sc
+  :event_classes:
+  - :name: ^event_[1-2]$
+    :callback_name: usr_event_1
+    :payload_field_class:
+      :type: structure
+      :members:
+      - :name: pf_1
+        :extract: false
+        :field_class:
+          :type: integer_unsigned
+          :cast_type: uint64_t
+  - :name: ^event_[1-2]$
+    :callback_name: usr_event_2
+    :payload_field_class:
+      :type: structure
+      :absent: true

--- a/test/callbacks/cases_matching_callbacks/11.btx_log.in
+++ b/test/callbacks/cases_matching_callbacks/11.btx_log.in
@@ -1,0 +1,2 @@
+event_1: { pf = 0 }
+event_2: 

--- a/test/callbacks/cases_matching_callbacks/11.btx_model.yaml
+++ b/test/callbacks/cases_matching_callbacks/11.btx_model.yaml
@@ -1,0 +1,12 @@
+:stream_classes:
+- :name: sc
+  :event_classes:
+  - :name: event_1
+    :payload_field_class:
+      :type: structure
+      :members:
+      - :name: pf_1
+        :field_class:
+          :type: integer_unsigned
+          :cast_type: uint64_t
+  - :name: event_2

--- a/test/callbacks/cases_matching_callbacks/11.callbacks.c
+++ b/test/callbacks/cases_matching_callbacks/11.callbacks.c
@@ -1,0 +1,15 @@
+#include <metababel/metababel.h>
+#include <assert.h>
+
+static void usr_event_callback_1(void *btx_handle, void *usr_data, const char * event_class_name) {
+  assert(strcmp(event_class_name,"event_1") == 0);
+}
+
+static void usr_event_callback_2(void *btx_handle, void *usr_data, const char * event_class_name) {
+  assert(strcmp(event_class_name,"event_2") == 0);
+}
+
+void btx_register_usr_callbacks(void *btx_handle) {
+  btx_register_callbacks_usr_event_1(btx_handle, &usr_event_callback_1);
+  btx_register_callbacks_usr_event_2(btx_handle, &usr_event_callback_2);
+}

--- a/test/callbacks/test_matching_callbacks.rb
+++ b/test/callbacks/test_matching_callbacks.rb
@@ -245,3 +245,26 @@ class TestMatchingEventNameArgNameArgTypeAndArgCastType < Test::Unit::TestCase
     @btx_output_validation = './test/callbacks/cases_matching_callbacks/10.btx_log.out'
   end
 end
+
+class TestMatchEventsWithAbsentPayloadField < Test::Unit::TestCase
+  include GenericTest
+  extend VariableAccessor
+  include VariableClassAccessor
+
+  def self.startup
+    @btx_components = [
+      {
+        btx_component_type: 'SOURCE',
+        btx_component_downstream_model: './test/callbacks/cases_matching_callbacks/11.btx_model.yaml',
+        btx_log_path: './test/callbacks/cases_matching_callbacks/11.btx_log.in',
+      },
+      {
+        btx_component_type: 'FILTER',
+        btx_component_upstream_model: './test/callbacks/cases_matching_callbacks/11.btx_model.yaml',
+        btx_component_downstream_model: './test/callbacks/cases_matching_callbacks/11.btx_model.yaml',
+        btx_component_callbacks: './test/callbacks/cases_matching_callbacks/11.btx_callbacks.yaml',
+        btx_file_usr_callbacks: './test/callbacks/cases_matching_callbacks/11.callbacks.c',
+      },
+    ]
+  end
+end


### PR DESCRIPTION
__Problem:__ How can we match events that don't have `:payload_field:`  to be **exclusively** dispatched by `usr_callback_1`?

Consider the sample Model below:

```yaml
:stream_classes:
- :name: sc
  :event_classes:
  - :name: event_1
     # No payload_field
  - :name: event_2
    :payload_field_class:
      :type: structure
      :members:
      - :name: pf_1
        :field_class:
          :type: integer_unsigned
          :cast_type: uint64_t
```

If we use the matching model below, it will match `event_1` and `event_2`. But we just want `event_1`.

```yaml
:stream_classes:
- :name: sc
  :event_classes:
  - :name: ^event_[1-2]$
    :callback_name: usr_event_1
```
On the other hand, if we use "negative match", as shown below, since the original model does not have `:payload_field:` it won't be considered as a match.

```yaml
:stream_classes:
- :name: sc
  :event_classes:
  - :name: ^event_[1-2]$
    :callback_name: usr_event_2
    :payload_field_class:
      :type: structure
      :members:
      - :name: ^(?!pf_1$)
        :field_class:
          :type: ^(?!integer_unsigned$)
          :cast_type: ^(?!uint64_t$)
```

__Possible solution__

Implement the `:absent:` keyword that tells the matching mechanism we want to match events where the payload (or any structure) is `absent`.

```yaml
:stream_classes:
- :name: sc
  :event_classes:
  - :name: ^event_[1-2]$
    :callback_name: usr_event_2
    :payload_field_class:
      :type: structure
      :absent: true
```