### PR TITLE
CTF roundtrip to catch packet field issue

### DIFF
--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -62,8 +62,36 @@ def get_component_compilation_command(component)
   command.split.join(' ')
 end
 
-def get_graph_execution_command(components, connections)
-  plugin_path = components.map { |c| c[:btx_component_path] }.uniq
+def _get_plugin_path(components)
+  components.map { |c| c[:btx_component_path] }.uniq
+end
+
+def _get_ctf_out_path(components)
+  plugin_path = _get_plugin_path(components).first
+  "#{plugin_path}/ctf_tmp"
+end
+
+def get_ctf_read_execution_command(components)
+  command = ''
+  if ENV['METABABEL_VALGRIND']
+    command += <<~TEXT
+      valgrind --suppressions=.valgrind/dlopen.supp
+               --error-exitcode=1
+               --leak-check=full
+               --quiet
+               --
+    TEXT
+  end
+
+  ctf_out_path = _get_ctf_out_path(components)
+  command += <<~TEXT
+    babeltrace2 #{ctf_out_path}
+  TEXT
+  command.split.join(' ')
+end
+
+def get_graph_execution_command(components, connections, write_ctf=false)
+  plugin_path = _get_plugin_path(components)
   components_list = components.map do |c|
     uuid = %w[type plugin_name name].map { |l| c["btx_component_#{l}".to_sym].downcase }.join('.')
     uuid_label = [c[:btx_component_label], uuid].compact.join(':')
@@ -84,11 +112,18 @@ def get_graph_execution_command(components, connections)
     TEXT
   end
 
+  extra_args = ''
+  if write_ctf
+    ctf_out_path = _get_ctf_out_path(components)
+    extra_args = "-o ctf -w #{ctf_out_path}"
+  end
+
   command += <<~TEXT
     babeltrace2 --plugin-path=#{plugin_path.join(':')}
                 #{components_connections.empty? ? '' : 'run'}
                 #{components_list.join(' ')}
                 #{components_connections.join(' ')}
+                #{extra_args}
   TEXT
   command.split.join(' ')
 end
@@ -160,13 +195,26 @@ module GenericTest
     end
     return if sanitized_components.empty?
 
+    has_sink = sanitized_components.join(' ').include?('sink')
+
     # Run the Graph
     stdout_str = run_command(get_graph_execution_command(sanitized_components, btx_connect))
+
+    stdout_str_readctf = ''
+    if not has_sink
+      # Round trip through CTF format and back to pretty print
+      run_command(get_graph_execution_command(sanitized_components, btx_connect, true))
+      stdout_str_readctf = run_command(get_ctf_read_execution_command(sanitized_components))
+    end
+
     # Output validation
     return unless btx_output_validation
 
     expected_output = File.read(btx_output_validation)
     assert_equal(expected_output, stdout_str)
+    if not has_sink
+      assert_equal(expected_output, stdout_str_readctf)
+    end
   end
 end
 

--- a/test/model/cases_model_constructs/9.btx_log.txt
+++ b/test/model/cases_model_constructs/9.btx_log.txt
@@ -1,0 +1,4 @@
+event_1: 
+event_2: 
+event_2: 
+event_1: 

--- a/test/model/cases_model_constructs/9.btx_model.yaml
+++ b/test/model/cases_model_constructs/9.btx_model.yaml
@@ -6,4 +6,6 @@
     - :name: dummy
       :field_class:
         :type: string
-  :event_classes: []
+  :event_classes:
+  - :name: event_1
+  - :name: event_2

--- a/test/model/test_model_constructs.rb
+++ b/test/model/test_model_constructs.rb
@@ -134,7 +134,9 @@ class TestPacketContextField < Test::Unit::TestCase
       {
         btx_component_type: 'SOURCE',
         btx_component_downstream_model: './test/model/cases_model_constructs/9.btx_model.yaml',
+        btx_log_path: './test/model/cases_model_constructs/9.btx_log.txt',
       },
     ]
+    @btx_output_validation = './test/model/cases_model_constructs/9.btx_log.txt'
   end
 end


### PR DESCRIPTION
Adds a CTF roundtrip to tests with no sink component.

This catches a bug in packet context field handling, which causes a segfault when writing to CTF but works fine with pretty print.